### PR TITLE
add support for Travis/macOS with xcode9.3 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,25 @@
 language: go
-sudo: required
-dist: trusty
-os:
-  - linux
-  - osx
 env:
   global:
     - CGO_ENABLED: 0
-  matrix:
-    - POSTGRESQL_VERSION=9.2
-    - POSTGRESQL_VERSION=9.3
-    - POSTGRESQL_VERSION=9.4
-    - POSTGRESQL_VERSION=9.5
-    - POSTGRESQL_VERSION=9.6
-    - POSTGRESQL_VERSION=10
-    - RABBITMQ_VERSION=any
 matrix:
   fast_finish: true
-  exclude:
-    - os: linux
-      env: POSTGRESQL_VERSION=10
-    - os: osx
-      env: POSTGRESQL_VERSION=9.2
-    - os: osx
-      env: POSTGRESQL_VERSION=9.3
+  # osx_image does not expand build matrix, so we have to build it manually here
+  # https://github.com/travis-ci/travis-ci/issues/7587
+  include:
+    - {os: linux, dist: trusty, sudo: required, env: 'POSTGRESQL_VERSION=9.2'}
+    - {os: linux, dist: trusty, sudo: required, env: 'POSTGRESQL_VERSION=9.3'}
+    - {os: linux, dist: trusty, sudo: required, env: 'POSTGRESQL_VERSION=9.4'}
+    - {os: linux, dist: trusty, sudo: required, env: 'POSTGRESQL_VERSION=9.5'}
+    - {os: linux, dist: trusty, sudo: required, env: 'POSTGRESQL_VERSION=9.6'}
+    - {os: linux, dist: trusty, sudo: required, env: 'PRABBITMQ_VERSION=any'}
+    - {os: osx, osx_image: xcode8.3,            env: 'POSTGRESQL_VERSION=9.4'}
+    - {os: osx, osx_image: xcode8.3,            env: 'POSTGRESQL_VERSION=9.5'}
+    - {os: osx, osx_image: xcode8.3,            env: 'POSTGRESQL_VERSION=9.6'}
+    - {os: osx, osx_image: xcode8.3,            env: 'POSTGRESQL_VERSION=10'}
+    - {os: osx, osx_image: xcode8.3,            env: 'RABBITMQ_VERSION=any'}
+    - {os: osx, osx_image: xcode9.3,            env: 'POSTGRESQL_VERSION=9.4'}
+    - {os: osx, osx_image: xcode9.3,            env: 'POSTGRESQL_VERSION=9.5'}
+    - {os: osx, osx_image: xcode9.3,            env: 'POSTGRESQL_VERSION=9.6'}
+    - {os: osx, osx_image: xcode9.3,            env: 'POSTGRESQL_VERSION=10'}
+    - {os: osx, osx_image: xcode9.3,            env: 'RABBITMQ_VERSION=any'}

--- a/common.go
+++ b/common.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/user"
 	"runtime"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ type Env struct {
 	Provider string
 	OS       string
 	Arch     string
+	User     *user.User
 }
 
 const (
@@ -54,10 +56,16 @@ func GetEnv() (*Env, error) {
 		return nil, err
 	}
 
+	u, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get current user: %s", err)
+	}
+
 	return &Env{
 		Provider: p,
 		OS:       runtime.GOOS,
 		Arch:     runtime.GOARCH,
+		User:     u,
 	}, nil
 }
 

--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -87,6 +87,18 @@ func installRabbitTravisLinux(env *Env, version string) error {
 }
 
 func installRabbitTravisOSX(env *Env, version string) error {
+	// High Sierra does not come with /usr/local/sbin by default,
+	// which makes linking some Homebrew packages fail.
+	if err := Run("sudo", "mkdir", "-p", "/usr/local/sbin"); err != nil {
+		return err
+	}
+
+	if err := Run("sudo", "chown", "-R",
+		fmt.Sprintf("%s:admin", env.User.Username),
+		"/usr/local/sbin"); err != nil {
+		return err
+	}
+
 	if err := Run("brew", "install", "rabbitmq"); err != nil {
 		return err
 	}


### PR DESCRIPTION
* add Travis tests for xcode9.3. `osx_image` does not expand the build matrix: https://github.com/travis-ci/travis-ci/issues/7587
  so we have to specify it manually, thanks to @mxcl for the trick: https://github.com/travis-ci/travis-ci/issues/7587#issuecomment-330700855

* rabbitmq: fix on Travis/macOS xcode9.3

rabbitmq fails to install on Travis/macOS xcode9.3 image by default with error:

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink sbin/cuttlefish
/usr/local/sbin is not writable.
```

This seems to be a general problem of Homebrew with macOS High Sierra, since it does not have /usr/local/sbin created by default.

We create now /usr/local/sbin beforehand to avoid the error.